### PR TITLE
Revert "IASECC/Gemalto: add support"

### DIFF
--- a/.github/setup-macos.sh
+++ b/.github/setup-macos.sh
@@ -2,7 +2,7 @@
 
 set -ex -o xtrace
 
-brew install automake gengetopt help2man autoconf libtool pkg-config m4
+brew install automake gengetopt help2man autoconf libtool m4
 
 # openSCToken
 export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/setup-macos.sh
+++ b/.github/setup-macos.sh
@@ -2,7 +2,7 @@
 
 set -ex -o xtrace
 
-brew install automake gengetopt help2man
+brew install automake gengetopt help2man autoconf libtool pkg-config m4
 
 # openSCToken
 export PATH="/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,12 +27,12 @@ jobs:
           CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           INSTALLER_SIGN_IDENTITY: ${{ secrets.INSTALLER_SIGN_IDENTITY }}
-      - name: Cache build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: opensc-build-macos
-          path:
-            OpenSC*.dmg
+      # - name: Cache build artifacts
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: opensc-build-macos
+      #     path:
+      #       OpenSC*.dmg
       - run: .github/cleanup-macos.sh
         env:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/src/libopensc/card-iasecc.c
+++ b/src/libopensc/card-iasecc.c
@@ -920,7 +920,6 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 
 	sc_print_cache(card);
 	if ((!iasecc_is_cpx(card)) &&
-	    (card->type != SC_CARD_TYPE_IASECC_GEMALTO) &&
 	    (path->type != SC_PATH_TYPE_DF_NAME
 			&& lpath.len >= 2
 			&& lpath.value[0] == 0x3F && lpath.value[1] == 0x00))   {
@@ -1018,7 +1017,6 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 			    card->type == SC_CARD_TYPE_IASECC_AMOS ||
 			    card->type == SC_CARD_TYPE_IASECC_MI ||
 			    card->type == SC_CARD_TYPE_IASECC_MI2 ||
-			    card->type == SC_CARD_TYPE_IASECC_GEMALTO ||
 			    iasecc_is_cpx(card)
 			    )   {
 				apdu.p2 = 0x04;
@@ -1030,7 +1028,6 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 			    card->type == SC_CARD_TYPE_IASECC_AMOS ||
 			    card->type == SC_CARD_TYPE_IASECC_MI ||
 			    card->type == SC_CARD_TYPE_IASECC_MI2 ||
-			    card->type == SC_CARD_TYPE_IASECC_GEMALTO ||
 			    iasecc_is_cpx(card)) {
 				apdu.p2 = 0x04;
 			}
@@ -1045,7 +1042,6 @@ iasecc_select_file(struct sc_card *card, const struct sc_path *path,
 			if (card->type == SC_CARD_TYPE_IASECC_AMOS ||
 			    card->type == SC_CARD_TYPE_IASECC_MI2 ||
 			    card->type == SC_CARD_TYPE_IASECC_OBERTHUR ||
-			    card->type == SC_CARD_TYPE_IASECC_GEMALTO ||
 			    iasecc_is_cpx(card)) {
 				apdu.p2 = 0x04;
 			}


### PR DESCRIPTION
This reverts commit e93bd3983ca135f63dc8860febca3ee7f702853a.

It broke support for Gemalto MultiApp IAS/ECC v1.0.1, which can't select files anymore. Propably we need a better way to distinguesh this card from CARTE IAS ECC DUAL ID ONE COSMO.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Mention which card(s) are used during testing. To get the name of your card,
run this command: `opensc-tool -n`
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] Documentation is added or updated
- [ ] New files have a LGPL 2.1 license statement
- [ ] PKCS#11 module is tested
- [ ] Windows minidriver is tested
- [ ] macOS tokend is tested
